### PR TITLE
Ensure arg parsing inserts into the runtime correctly

### DIFF
--- a/Sources/octahe/operations/target.swift
+++ b/Sources/octahe/operations/target.swift
@@ -53,7 +53,6 @@ class TargetRecord {
             }
         }
         self.conn.target = target.name
-
         if let escalate = self.target.escalate {
             logger.debug("Setting an escallation password object")
             self.conn.escalate = escalate


### PR DESCRIPTION
extra ARG parsing will now replace an existing ARG in a Containerfile
if defined on the CLI and insert into the runtime if there's no arg to
replace. This change will allow operators to define static Containerfiles
with ARGs and allow for the modification at runtime.

Signed-off-by: Kevin Carter <kecarter@redhat.com>