### PR TITLE
Remove the use of open-crypto from vapor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,24 +11,6 @@
         }
       },
       {
-        "package": "Core",
-        "repositoryURL": "https://github.com/vapor/core.git",
-        "state": {
-          "branch": null,
-          "revision": "1782c550512dc5a43d0bca405e28fc386d932bbf",
-          "version": "3.10.0"
-        }
-      },
-      {
-        "package": "Crypto",
-        "repositoryURL": "https://github.com/vapor/open-crypto",
-        "state": {
-          "branch": null,
-          "revision": "105c2f875588bf40dd24c00cef3644bf8e327770",
-          "version": "3.4.1"
-        }
-      },
-      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
@@ -83,39 +65,21 @@
         }
       },
       {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto",
+        "state": {
+          "branch": null,
+          "revision": "9b9d1868601a199334da5d14f4ab2d37d4f8d0c5",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
           "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
           "version": "1.2.0"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "8da5c5a4e6c5084c296b9f39dc54f00be146e0fa",
-          "version": "1.14.2"
-        }
-      },
-      {
-        "package": "swift-nio-ssl-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
-        "state": {
-          "branch": null,
-          "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "octahe",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "0.1.0"),
         .package(name: "swift-log", url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
-        .package(name: "Crypto", url: "https://github.com/vapor/open-crypto", .upToNextMinor(from: "3.4.1")),
+        .package(name: "swift-crypto", url: "https://github.com/apple/swift-crypto", from: "1.0.2"),
         .package(name: "SwiftSerial", url: "https://github.com/yeokm1/SwiftSerial.git", from: "0.1.2"),
         .package(name: "Spinner", url: "https://github.com/dominicegginton/Spinner", from: "1.1.4"),
         .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil", from: "0.13.0"),
@@ -32,7 +32,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Crypto", package: "Crypto"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "SwiftSerial", package: "SwiftSerial"),
                 .product(name: "Spinner", package: "Spinner"),
                 .product(name: "Stencil", package: "Stencil"),

--- a/Sources/octahe/mixin.swift
+++ b/Sources/octahe/mixin.swift
@@ -139,9 +139,8 @@ extension String {
     }
 
     var sha1: String {
-        // swiftlint:disable force_try
-        let digest = try! SHA1.hash(self)
-        return digest.hexEncodedString()
+        let digest = Insecure.SHA1.hash(data: Data(self.utf8))
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
     }
 
     func toInt() throws -> Int32 {


### PR DESCRIPTION
This change removes open-crypto from vapor because its being considered for archive [0]
due to the release of swift-crypto. Octahe will now depend on swift-crypto going
forward.

[0] https://github.com/vapor/open-crypto/issues/99

Signed-off-by: Kevin Carter <kecarter@redhat.com>