### PR TITLE
Improve comment parser and add functional tests for it

### DIFF
--- a/.testcontainer/Targetfile.local
+++ b/.testcontainer/Targetfile.local
@@ -20,3 +20,10 @@ RUN env > test-env
 RUN stat /tmp/test-env
 RUN rm test-env
 RUN stat /tmp/test-env || echo success
+
+# This is a comment command that should never run
+# RUN false
+
+RUN echo -e "This is a# in-code test" > /tmp/comment-test
+RUN grep "This is a# in-code test" /tmp/comment-test
+RUN rm /tmp/comment-test # Inline comment test.

--- a/Sources/octahe/mixin.swift
+++ b/Sources/octahe/mixin.swift
@@ -24,7 +24,7 @@ let allOctaheDeployVerbs: [String] = allSupportedVerbs.filter {item in
 }
 
 let allOctaheFromVerbs: [String] = allSupportedVerbs.filter {item in
-    return !["ADD", "COPY"].contains(item)
+    return !["ADD", "COPY", "VOLUME", "ONBUILD"].contains(item)
 }
 
 var logger = Logger(label: "com.octahe")

--- a/Sources/octahe/parsers/containerFile.swift
+++ b/Sources/octahe/parsers/containerFile.swift
@@ -26,7 +26,7 @@ class FileParser {
     init() {}
 
     func trimLine(line: String) -> String {
-        let trimmed = line.replacingOccurrences(of: "#[^!].*", with: "", options: [.regularExpression])
+        let trimmed = line.replacingOccurrences(of: "(^#[^!*].*|\\s{1}#[^!*].*)", with: "", options: [.regularExpression])
         var trimmedLine = trimmed.strip
         if trimmedLine.hasSuffix(" \\") {
             trimmedLine = trimmedLine.replacingOccurrences(of: "\\", with: "")


### PR DESCRIPTION
This change will ensure Octahe is not matching on comments that are inline
code. To ensure this is working, both an inline comment, and an in-code "#"
have been used ensuring that it will be exercised on all program executions.

Signed-off-by: Kevin Carter <kecarter@redhat.com>