### PR TITLE
Update fataFrom to the localExec method

### DIFF
--- a/Sources/octahe/executions/execute.swift
+++ b/Sources/octahe/executions/execute.swift
@@ -28,6 +28,7 @@ class Execution {
     var stopsignal: String?
     var documentation: [[String: String]] = [["item": "https://github.com/peznauts/octahe.swift"]]
     var interface: String?
+    var fatalExec: Bool = true
 
     init(cliParameters: OctaheCLI.Options, processParams: ConfigParse) {
         self.cliParams = cliParameters
@@ -94,7 +95,7 @@ class Execution {
         pipe.fileHandleForReading.waitForDataInBackgroundAndNotify()
         let output = pipe.fileHandleForReading.availableData
         let outputInfo = String(data: output, encoding: String.Encoding.utf8)!
-        if task.terminationStatus != 0 {
+        if task.terminationStatus != 0 && self.fatalExec {
             var message = "STATUS: \(task.terminationStatus)"
             message += " REASON: \(task.terminationReason)"
             message += " OUTPUT: \(outputInfo)"

--- a/Sources/octahe/operations/inspect.swift
+++ b/Sources/octahe/operations/inspect.swift
@@ -123,15 +123,7 @@ class Inspection {
                         self.inspectionRecord?.items.append(Substring(cmdGroup))
                     }
                 } else {
-                    let runCmd: Substring
-                    switch self.fatalFrom {
-                    case true:
-                        logger.debug("Instruction being added as fatal")
-                        runCmd = "RUN \(cmdGroup)"
-                    default:
-                        runCmd = "RUN \(cmdGroup) || true"
-                    }
-                    self.inspectionRecord?.items.append(runCmd)
+                    self.inspectionRecord?.items.append(Substring("RUN \(cmdGroup)"))
                 }
             }
         }

--- a/Sources/octahe/operations/target.swift
+++ b/Sources/octahe/operations/target.swift
@@ -144,6 +144,7 @@ class TargetOperation: Operation {
 
     // swiftlint:disable cyclomatic_complexity
     private func targetCases() throws {
+        self.targetRecord.conn.fatalExec = self.task.taskItem.fatalExec
         switch self.task.task {
         case "SHELL":
             self.targetRecord.conn.shell = self.task.taskItem.execute!

--- a/Sources/octahe/operations/task.swift
+++ b/Sources/octahe/operations/task.swift
@@ -59,7 +59,7 @@ class TaskOperation: Operation {
         if let taskRecordsLookup = taskQueue.taskRecords[stepIndex] {
             self.taskRecord = taskRecordsLookup
         } else {
-            let taskRecordsLookup = TaskRecord(task: deployItem.key, taskItem: deployItem.value)
+            let taskRecordsLookup = TaskRecord(task: self.deployItem.key, taskItem: self.deployItem.value)
             taskQueue.taskRecords[stepIndex] = taskRecordsLookup
             self.taskRecord = taskQueue.taskRecords[stepIndex]!
         }
@@ -131,7 +131,7 @@ class TaskOperation: Operation {
             return
         }
         self.statusLineFull = String(
-            format: "Step \(stepIndex)/\(steps) : \(deployItem.key) \(deployItem.value.original)"
+            format: "Step \(stepIndex)/\(steps) : \(self.deployItem.key) \(self.deployItem.value.original)"
         )
         self.statusLine = statusLineFull?.trunc(length: 77)
         targetQueue.nodeQueue.addOperations(self.queueTaskOperations(), waitUntilFinished: true)

--- a/Sources/octahe/router.swift
+++ b/Sources/octahe/router.swift
@@ -95,6 +95,9 @@ final class Router {
         logger.info(
             "Adding \(fromItems.count) instructions into the deployment FROM: \(self.octaheArgs.octaheFrom)"
         )
+        if self.parsedOptions.fatalFrom {
+            logger.debug("FROM instructions will be fatal")
+        }
         for item in fromItems {
             switch item.key {
             case "FROM":
@@ -102,7 +105,9 @@ final class Router {
                 try inspect.main()
                 try self.insertFrom(inspect: inspect)
             default:
-                self.octaheArgs.octaheDeploy.insert(try self.octaheArgs.deploymentCases(item), at: 0)
+                let deployItem = try self.octaheArgs.deploymentCases(item)
+                deployItem.value.fatalExec = self.parsedOptions.fatalFrom
+                self.octaheArgs.octaheDeploy.insert(deployItem, at: 0)
             }
         }
     }

--- a/Sources/octahe/types.swift
+++ b/Sources/octahe/types.swift
@@ -56,6 +56,7 @@ class TypeDeploy {
     let escalatePassword: String?
     let exposeData: TypeExposes?
     let workdir: String?
+    var fatalExec: Bool = true
 
     init (execute: String? = nil, chown: String? = nil, location: [String]? = [], destination: String? = nil,
           from: String? = nil, original: String, env: [String: String]? = nil, user: String? = nil,


### PR DESCRIPTION
fatalFrom will now ignore execution return codes instead of modifying run
commands. This change improves the UX and ensures the clean handling of
included instructions.

Signed-off-by: Kevin Carter <kecarter@redhat.com>