### PR TITLE
Remove brew and conditionally include libs with system deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install libressl
-      run: brew install libressl
     - name: Build Octahe
       run: swift build --configuration release -Xswiftc -g
-      env:
-        LDFLAGS: "-L/usr/local/opt/libressl/lib"
-        CPPFLAGS: "-I/usr/local/opt/libressl/include"
-        PKG_CONFIG_PATH: "/usr/local/opt/libressl/lib/pkgconfig"
     - name: Upload Octahe release
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -68,14 +62,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install libressl
-      run: brew install libressl
     - name: Build Octahe
       run: swift build --configuration release -Xswiftc -g
-      env:
-        LDFLAGS: "-L/usr/local/opt/libressl/lib"
-        CPPFLAGS: "-I/usr/local/opt/libressl/include"
-        PKG_CONFIG_PATH: "/usr/local/opt/libressl/lib/pkgconfig"
     - name: Install build DMG
       run: ./scripts/dmg-build.sh
     - name: Upload Octahe release

--- a/.github/workflows/swift-docker-pull.yml
+++ b/.github/workflows/swift-docker-pull.yml
@@ -94,14 +94,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install libressl
-      run: brew install libressl
     - name: Build Octahe
       run: swift build
-      env:
-        LDFLAGS: "-L/usr/local/opt/libressl/lib"
-        CPPFLAGS: "-I/usr/local/opt/libressl/include"
-        PKG_CONFIG_PATH: "/usr/local/opt/libressl/lib/pkgconfig"
     - name: Run local test
       run: .build/debug/octahe deploy --targets=localhost .testcontainer/Targetfile.local --debug
     - name: Install build DMG

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,12 @@
         }
       },
       {
-        "package": "Core",
-        "repositoryURL": "https://github.com/vapor/core.git",
-        "state": {
-          "branch": null,
-          "revision": "1782c550512dc5a43d0bca405e28fc386d932bbf",
-          "version": "3.10.0"
-        }
-      },
-      {
-        "package": "HTTP",
+        "package": "http-kit",
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
-          "branch": null,
-          "revision": "fba1329cd430e2f9a3f995b317b04f268d8b2978",
-          "version": "3.3.2"
+          "branch": "master",
+          "revision": "3e49ea0b7c16ee0e0985babff9659d467d4f59fd",
+          "version": null
         }
       },
       {
@@ -95,9 +86,9 @@
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
-          "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
+          "branch": "master",
+          "revision": "de30f5bfc245f0bf15de114b8668f264739585c1",
+          "version": null
         }
       },
       {
@@ -105,34 +96,43 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8da5c5a4e6c5084c296b9f39dc54f00be146e0fa",
-          "version": "1.14.2"
+          "revision": "acf5465b5e7fb9aeda54a34d16fb44c31a399715",
+          "version": "2.20.2"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "d525d3bbd1321fa928948065fd9a8dc109d5d45b",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "c76a9a5085bfc22882f8cff88189662af30806e8",
+          "version": "1.12.3"
         }
       },
       {
         "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl",
         "state": {
           "branch": null,
-          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
-          "version": "1.4.0"
+          "revision": "8a137b72a9339f295bc8bb95cd2fafe207f1df0d",
+          "version": "2.9.0"
         }
       },
       {
         "package": "swift-nio-ssl-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support.git",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl-support",
         "state": {
           "branch": null,
           "revision": "c02eec4e0e6d351cd092938cf44195a8e669f555",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
           "version": "1.0.0"
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -16,31 +16,32 @@ let package = Package(
         )
     ],
     dependencies: [
+        .package(name: "swift-nio-ssl", url: "https://github.com/apple/swift-nio-ssl", from: "2.9.0"),
+        .package(name: "swift-nio-ssl-support", url: "https://github.com/apple/swift-nio-ssl-support", from: "1.0.0"),
+        .package(name: "swift-crypto", url: "https://github.com/apple/swift-crypto", from: "1.0.2"),
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser", from: "0.1.0"),
         .package(name: "swift-log", url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
-        .package(name: "swift-crypto", url: "https://github.com/apple/swift-crypto", from: "1.0.2"),
         .package(name: "SwiftSerial", url: "https://github.com/yeokm1/SwiftSerial.git", from: "0.1.2"),
         .package(name: "Spinner", url: "https://github.com/dominicegginton/Spinner", from: "1.1.4"),
         .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil", from: "0.13.0"),
-        .package(name: "HTTP", url: "https://github.com/vapor/http.git", from: "3.0.0")
+        .package(name: "http-kit", url: "https://github.com/vapor/http.git", .branch("master"))
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "octahe",
             dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "SwiftSerial", package: "SwiftSerial"),
                 .product(name: "Spinner", package: "Spinner"),
                 .product(name: "Stencil", package: "Stencil"),
-                .product(name: "HTTP", package: "HTTP"),
+                .product(name: "HTTPKit", package: "http-kit")
             ]
         ),
         .testTarget(
             name: "octaheTests",
-            dependencies: ["octahe"]),
+            dependencies: ["octahe"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -80,20 +80,6 @@ the [releases](https://github.com/peznauts/octahe.swift/releases).
 In order to build Octahe on macOS you will need OSX 10.15 or better. You will also need
 XCode installed and updated to the latest stable release.
 
-Make sure you have `libressl` installed. This can easily be accomplished using brew.
-
-``` shell
-brew install libressl
-```
-
-Once `libressl` has been installed, export the build options required to build Octahe.
-
-``` shell
-export LDFLAGS="-L/usr/local/opt/libressl/lib"
-export CPPFLAGS="-I/usr/local/opt/libressl/include"
-export PKG_CONFIG_PATH="/usr/local/opt/libressl/lib/pkgconfig"
-```
-
 #### Octahe dependencies on CentOS 8
 
 Install `EPEL`.

--- a/Sources/octahe/mixin.swift
+++ b/Sources/octahe/mixin.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
+#if os(Linux)
 import Crypto
+#else
+import CryptoKit
+#endif
 
 import Logging
 

--- a/Sources/octahe/operations/inspect.swift
+++ b/Sources/octahe/operations/inspect.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import HTTP
+import HTTPKit
 
 struct DockerToken: Codable {
     var token: String
@@ -52,19 +52,21 @@ class Inspection {
     var headers: HTTPHeaders = .init()
     let decoder: JSONDecoder = JSONDecoder()
     var fatalFrom: Bool = false
+    var hostname: String = "auth.docker.io"
 
     init() {
         self.requestQueue = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
 
     private func createClient(hostname: String = "auth.docker.io") throws {
-        self.client = try HTTPClient.connect(scheme: .https, hostname: hostname, on: self.requestQueue).wait()
+        self.client = HTTPClient(on: self.requestQueue)
+        self.hostname = hostname
     }
 
     private func makeRequest(urlString: String) throws -> HTTPBody {
         var httpReq = HTTPRequest(
             method: .GET,
-            url: urlString,
+            url: "https://\(hostname)" + urlString,
             headers: self.headers
         )
         logger.debug("URL: \(httpReq.url)")


### PR DESCRIPTION
This change removes the requirement to install ressl on a macos
environment. This will ensure we have a streamlined installation
process and limit the requirement for users to have development
libs on their systems.

Signed-off-by: Kevin Carter <kecarter@redhat.com>